### PR TITLE
Remove Stash Pre-declarations

### DIFF
--- a/UV.xs
+++ b/UV.xs
@@ -270,21 +270,21 @@ static uv_handle_t* handle_new(const uv_handle_type type)
 static const char * handle_namespace(const uv_handle_type type)
 {
     switch (type) {
-        case UV_ASYNC: return "UV::Async"; break;
-        case UV_CHECK: return "UV::Check"; break;
-        case UV_FS_EVENT: return "UV::FSEvent"; break;
-        case UV_FS_POLL: return "UV::FSPoll"; break;
-        case UV_IDLE: return "UV::Idle"; break;
-        case UV_NAMED_PIPE: return "UV::NamedPipe"; break;
-        case UV_POLL: return "UV::Poll"; break;
-        case UV_PREPARE: return "UV::Prepare"; break;
-        case UV_PROCESS: return "UV::Process"; break;
-        case UV_STREAM: return "UV::Stream"; break;
-        case UV_TCP: return "UV::TCP"; break;
-        case UV_TIMER: return "UV::Timer"; break;
-        case UV_TTY: return "UV::TTY"; break;
-        case UV_UDP: return "UV::UDP"; break;
-        case UV_SIGNAL: return "UV::Signal"; break;
+        case UV_ASYNC: return "UV::Async";
+        case UV_CHECK: return "UV::Check";
+        case UV_FS_EVENT: return "UV::FSEvent";
+        case UV_FS_POLL: return "UV::FSPoll";
+        case UV_IDLE: return "UV::Idle";
+        case UV_NAMED_PIPE: return "UV::NamedPipe";
+        case UV_POLL: return "UV::Poll";
+        case UV_PREPARE: return "UV::Prepare";
+        case UV_PROCESS: return "UV::Process";
+        case UV_STREAM: return "UV::Stream";
+        case UV_TCP: return "UV::TCP";
+        case UV_TIMER: return "UV::Timer";
+        case UV_TTY: return "UV::TTY";
+        case UV_UDP: return "UV::UDP";
+        case UV_SIGNAL: return "UV::Signal";
         default:
             croak("Invalid handle type supplied");
     }

--- a/typemap
+++ b/typemap
@@ -21,14 +21,13 @@ T_RUN_UV
     $var = SvIV($arg)
 
 T_LOOP
-    if (!(SvROK ($arg) && SvOBJECT (SvRV ($arg)) && (SvSTASH (SvRV ($arg)) == stash_loop || sv_derived_from ($arg, \"UV::Loop\"))))
+    if (!(SvROK($arg) && SvOBJECT(SvRV ($arg)) && sv_derived_from($arg, \"UV::Loop\")))
         croak (\"object is not of type UV::Loop\");
     $var = ($type)SvIVX (SvRV ($arg));
 
 T_HANDLE
     if (!(SvROK ($arg) && SvOBJECT (SvRV ($arg))
-      && (SvSTASH (SvRV ($arg)) == stash_" . ($type =~ /uv_([^_\s]+)/, "$1") . "
-      || sv_derived_from ($arg, \"UV::" . ($type =~ /uv_([^_\s]+)/, ucfirst "$1") . "\"))))
+      && (sv_derived_from ($arg, \"UV::" . ($type =~ /uv_([^_\s]+)/, ucfirst "$1") . "\"))))
          croak (\"object is not of type UV::" . ($type =~ /uv_([^_\s]+)/, ucfirst "$1") . "\");
     $var = ($type)SvPVX (SvRV ($arg));
 


### PR DESCRIPTION
In a first step towards thread-safety, let's stop declaring stashes in the ```BOOT``` area and thus no longer worry about having to store them in a context.