### PR TITLE
simplify DO_CONST_*

### DIFF
--- a/lib/p5uv_constants.h
+++ b/lib/p5uv_constants.h
@@ -25,12 +25,17 @@
                          (UV_VERSION_PATCH))
 #endif
 
+/* needed for compatibility with perls 5.14 and older */
+#ifndef newCONSTSUB_flags
+#define newCONSTSUB_flags(stash, name, len, flags, sv) newCONSTSUB((stash), (name), (sv))
+#endif
+
 #define DO_CONST_IV(c) \
-    newCONSTSUB(stash, #c, newSViv(c)); \
-    av_push(export, newSVpv(#c, 0));
+    newCONSTSUB_flags(stash, #c, strlen(#c), 0, newSViv(c)); \
+    av_push(export, newSVpvs(#c));
 #define DO_CONST_PV(c) \
-    newCONSTSUB(stash, #c, newSVpvf("%s", c)); \
-    av_push(export, newSVpv(#c, 0));
+    newCONSTSUB_flags(stash, #c, strlen(#c), 0, newSVpvn(c, strlen(c))); \
+    av_push(export, newSVpvs(#c));
 
 /* all of these call Perl API functions and should have thread context */
 extern void constants_export_uv(pTHX);


### PR DESCRIPTION
- newSVpvf() was an overkill, we don't need to format our string,
  use newSVpvn() instead.

- use newSVpvs() instead of newSVpv(), it's the most efficient way
  to make SVs from string literals.

- replace newCONSTSUB() with newCONSTSUB_flags(). The latter is
  a bit more low-level which makes it *slightly* cheaper.

Note that the newly added strlen() calls on constant strings will get
optimized-out, which means they are 100% free.