### PR TITLE
Remove $handle->ref, ->unref and ->has_ref from external API

### DIFF
--- a/lib/UV/Handle.pm
+++ b/lib/UV/Handle.pm
@@ -297,15 +297,6 @@ method returns non-zero if the handle is closing or closed, zero otherwise.
 B<* Note:> This function should only be used between the initialization of the
 handle and the arrival of the C<close> callback.
 
-=head2 has_ref
-
-    my $int = $handle->has_ref();
-
-The L<has_ref|http://docs.libuv.org/en/v1.x/handle.html#c.uv_has_ref>
-method returns non-zero if the handle is referenced, zero otherwise.
-
-See L<Reference Counting|http://docs.libuv.org/en/v1.x/handle.html#refcount>.
-
 =head2 on
 
     # set a close event callback to print the handle's data attribute
@@ -321,28 +312,6 @@ See L<Reference Counting|http://docs.libuv.org/en/v1.x/handle.html#refcount>.
 
 The C<on> method allows you to subscribe to L<UV::Handle/"EVENTS"> emitted by
 any UV::Handle or subclass.
-
-=head2 ref
-
-    $handle->ref();
-
-The L<ref|http://docs.libuv.org/en/v1.x/handle.html#c.uv_ref>
-method references the given handle. References are idempotent, that is, if a
-handle is already referenced, then calling this function again will have no
-effect.
-
-See L<Reference Counting|http://docs.libuv.org/en/v1.x/handle.html#refcount>.
-
-=head2 unref
-
-    $handle->unref();
-
-The L<unref|http://docs.libuv.org/en/v1.x/handle.html#c.uv_unref>
-method un-references the given handle. References are idempotent, that is, if a
-handle is not referenced, then calling this function again will have no
-effect.
-
-See L<Reference Counting|http://docs.libuv.org/en/v1.x/handle.html#refcount>.
 
 
 =head1 AUTHOR

--- a/lib/handle.xsi
+++ b/lib/handle.xsi
@@ -47,26 +47,3 @@ int p5uv_handle_closing(SV *self)
         RETVAL = uv_is_closing(handle);
     OUTPUT:
     RETVAL
-
-int p5uv_handle_has_ref(SV *self)
-    PREINIT:
-        uv_handle_t *handle;
-    CODE:
-        handle = (uv_handle_t *)xs_object_magic_get_struct_rv_pretty(aTHX_ self, "uv_handle_t in has_ref");
-        RETVAL = uv_has_ref(handle);
-    OUTPUT:
-    RETVAL
-
-void p5uv_handle_ref(SV *self)
-    PREINIT:
-        uv_handle_t *handle;
-    CODE:
-        handle = (uv_handle_t *)xs_object_magic_get_struct_rv_pretty(aTHX_ self, "uv_handle_t in ref");
-        uv_ref(handle);
-
-void p5uv_handle_unref(SV *self)
-    PREINIT:
-        uv_handle_t *handle;
-    CODE:
-        handle = (uv_handle_t *)xs_object_magic_get_struct_rv_pretty(aTHX_ self, "uv_handle_t in unref");
-        uv_unref(handle);

--- a/t/01-can-uv-check.t
+++ b/t/01-can-uv-check.t
@@ -8,7 +8,7 @@ use Test::More;
 # are all of the UV::Handle functions exportable as we expect?
 can_ok('UV::Check', (
     qw(new on close closed loop data),
-    qw(active closing has_ref ref unref),
+    qw(active closing),
 ));
 
 # are the extra methods also available?

--- a/t/01-can-uv-handle.t
+++ b/t/01-can-uv-handle.t
@@ -8,7 +8,7 @@ use Test::More;
 # are all of the functions exportable as we expect?
 can_ok('UV::Handle', (
     qw(new on close closed loop data),
-    qw(active closing has_ref ref unref),
+    qw(active closing),
 ));
 
 done_testing;

--- a/t/01-can-uv-idle.t
+++ b/t/01-can-uv-idle.t
@@ -8,7 +8,7 @@ use Test::More;
 # are all of the UV::Handle functions exportable as we expect?
 can_ok('UV::Idle', (
     qw(new on close closed loop data),
-    qw(active closing has_ref ref unref),
+    qw(active closing),
 ));
 
 # are the extra methods also available?

--- a/t/01-can-uv-poll.t
+++ b/t/01-can-uv-poll.t
@@ -8,7 +8,7 @@ use Test::More;
 # are all of the UV::Handle functions exportable as we expect?
 can_ok('UV::Poll', (
     qw(new on close closed loop data),
-    qw(active closing has_ref ref unref),
+    qw(active closing),
 ));
 
 # are the extra methods also available?

--- a/t/01-can-uv-prepare.t
+++ b/t/01-can-uv-prepare.t
@@ -8,7 +8,7 @@ use Test::More;
 # are all of the UV::Handle functions exportable as we expect?
 can_ok('UV::Prepare', (
     qw(new on close closed loop data),
-    qw(active closing has_ref ref unref),
+    qw(active closing),
 ));
 
 # are the extra methods also available?

--- a/t/01-can-uv-timer.t
+++ b/t/01-can-uv-timer.t
@@ -8,7 +8,7 @@ use Test::More;
 # are all of the UV::Handle functions exportable as we expect?
 can_ok('UV::Timer', (
     qw(new on close closed loop data),
-    qw(active closing has_ref ref unref),
+    qw(active closing),
 ));
 
 # are the extra methods also available?

--- a/t/03-timer-again.t
+++ b/t/03-timer-again.t
@@ -68,7 +68,7 @@ sub repeat_2_cb {
     $dummy = UV::Timer->new();
     isa_ok($dummy, 'UV::Timer', 'Got a new timer');
     is(UV::UV_EINVAL, $dummy->again(), '->again erred as expected');
-    $dummy->unref();
+    undef $dummy;
 
     # Start timer repeat_1
     $repeat_1 = UV::Timer->new();

--- a/t/03-timer.t
+++ b/t/03-timer.t
@@ -91,7 +91,7 @@ sub never_cb {
     isa_ok($never, 'UV::Timer', "Got a never timer");
     is(0, $never->start(100, 100, \&never_cb), 'never timer started');
     is(0, $never->stop(), 'never timer stopped');
-    $never->unref();
+    $never->close(undef);
 
     UV::Loop->default()->run();
 
@@ -100,7 +100,6 @@ sub never_cb {
     is($repeat_cb_called, 5, 'repeat_cb called 5 times');
     is($repeat_close_cb_called, 1, 'repeat_close_cb called once');
     ok(500 <= UV::Loop->default()->now() - $start_time, 'finished in < 500 ms');
-    $never->close(undef);
 }
 
 # timer start twice


### PR DESCRIPTION
The `uv_handle_ref()` and `_unref()` functions are very low-level refcount related hackery that are necessary for C and C-like languages to keep track of memory. These functions are useful things for a wrapping module like `UV.xs` to use internally, but they really shouldn't be exposed to the pure-perl users of UV.pm. Users must not expect to be able to ->unref things, as doing so will upset the internal refcount tracked by libuv in conjunction with UV.xs and might lead to things breaking.

Normal perl variable referencing is totally fine for this.