### PR TITLE
Win32 test fixes

### DIFF
--- a/t/08-signal.t
+++ b/t/08-signal.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use UV::Loop ();
-use UV::Signal qw(SIGHUP);
+use UV::Signal qw(SIGINT);
 
 use Test::More;
 
@@ -15,12 +15,12 @@ sub signal_cb {
     $self->close();
 }
 
-my $signal = UV::Signal->new(signal => SIGHUP, on_signal => \&signal_cb);
+my $signal = UV::Signal->new(signal => SIGINT, on_signal => \&signal_cb);
 isa_ok($signal, 'UV::Signal');
 my $ret = $signal->start();
 is($ret, $signal, '$signal->start returns $signal');
 
-kill SIGHUP => $$;
+kill SIGINT => $$;
 is(UV::Loop->default()->run(), 0, 'Default loop ran');
 
 is($signal_cb_called, 1, "The Signal callback was run");

--- a/t/11-tcp-open.t
+++ b/t/11-tcp-open.t
@@ -37,6 +37,24 @@ sub socketpair_inet
     return ($rd, $wr);
 }
 
+# Launch watchdog on Windows in background
+if( $^O eq 'MSWin32' ) {
+    my $ppid = $$;
+    my $child= system(1, $^X,'-e',"sleep 5; kill KILL => $ppid");
+    if( !$child ) {
+        diag "Could not launch watchdog: $^E";
+    } else {
+            note "Watchdog started (5 seconds)";
+    };
+    END {
+        if( $child ) {
+            kill KILL => $child
+                or diag "Could not kill watchdog: $^E";
+            note "Watchdog removed";
+        }
+    }
+}
+
 # read
 {
     my ($rd, $wr) = socketpair_inet();

--- a/t/11-tcp-open.t
+++ b/t/11-tcp-open.t
@@ -37,6 +37,23 @@ sub socketpair_inet
     return ($rd, $wr);
 }
 
+# Launch watchdog on Windows in background
+if( $^O eq 'MSWin32' ) {
+    my $child= system(1, $^X,'-e',"sleep 5; kill 9 => $$");
+    if( !$child ) {
+        diag "Could not launch watchdog: $^E";
+    } else {
+            note "Watchdog started (5 seconds)";
+    };
+    END {
+        if( $child ) {
+            kill 9 => $child
+                or diag "Could not kill watchdog: $^E";
+            note "Watchdog removed";
+        }
+    }
+}
+
 # read
 {
     my ($rd, $wr) = socketpair_inet();

--- a/t/30-process.t
+++ b/t/30-process.t
@@ -42,6 +42,9 @@ is($exit_cb_called, 1, "The exit callback was run");
     is($exit_status, 5, 'exit status from `perl -e "exit 5"`');
 }
 
+# WTF? This one kills the current process (this test) with a SIGBREAK
+# instead sending a SIGTERM, on Windows?!
+if( $^O ne 'MSWin32' )
 {
     my $term_signal;
 


### PR DESCRIPTION
These three changes make the test suite complete on Windows, instead of exiting the tests prematurely. There are some remaining test failures, but these can be revisited later:
```
C:\Users\Corion\Projekte\p5-UV>perl -Mblib t\05-poll-readable.t
Couldn't initialise poll handle for non-socket (-4050): socket operation on non-socket at C:\Users\Corion\Projekte\p5-UV\blib\lib/UV/Handle.pm line 22.

C:\Users\Corion\Projekte\p5-UV>perl -Mblib t\05-poll-writable.t
Couldn't initialise poll handle for non-socket (-4050): socket operation on non-socket at C:\Users\Corion\Projekte\p5-UV\blib\lib/UV/Handle.pm line 22.

C:\Users\Corion\Projekte\p5-UV>perl -Mblib t\12-udp-open.t
ok 1 - An object of class 'UV::UDP' isa 'UV::UDP'
Couldn't _open (-4071): invalid argument at C:\Users\Corion\Projekte\p5-UV\blib\lib/UV/UDP.pm line 17.
# Tests were run but no plan was declared and done_testing() was not seen.
# Looks like your test exited with 25 just after 1.
```

Most of these stem likely from treating socket handles like filehandles, which WIndows doesn't like.