### PR TITLE
Win32 test fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 Build
+Build.bat
 /MANIFEST.SKIP.bak
 /MANIFEST.bak
 META.YML

--- a/t/05-poll-readable.t
+++ b/t/05-poll-readable.t
@@ -12,7 +12,9 @@ use UV::Poll qw(UV_READABLE);
 # Feel free to 
 #   plan skip_all ... if $^O eq "MSWin32"
 
-pipe my ( $rd, $wr ) or die "Unable to pipe() - $!";
+use IO::Async::OS;
+my ( $rd, $wr ) = IO::Async::OS->pipepair
+     or die "Unable to pipe() - $!";
 
 my $poll_cb_called = 0;
 my ( $poll_cb_status, $poll_cb_events );

--- a/t/05-poll-writable.t
+++ b/t/05-poll-writable.t
@@ -12,7 +12,9 @@ use UV::Poll qw(UV_WRITABLE);
 # Feel free to 
 #   plan skip_all ... if $^O eq "MSWin32"
 
-pipe my ( $rd, $wr ) or die "Unable to pipe() - $!";
+use IO::Async::OS;
+my ( $rd, $wr ) = IO::Async::OS->pipepair
+     or die "Unable to pipe() - $!";
 
 my $poll_cb_called = 0;
 my ( $poll_cb_status, $poll_cb_events );

--- a/t/12-udp-open.t
+++ b/t/12-udp-open.t
@@ -19,10 +19,12 @@ sub socketpair_inet
     # Maybe socketpair(2) can do it?
     ($rd, $wr) = IO::Socket->socketpair(AF_INET, SOCK_DGRAM, 0)
         and return ($rd, $wr);
-
+    note "No socketpair";
     # If not, go the long way round
     $rd = IO::Socket::INET->new(
+        #LocalHost => "0.0.0.0",
         LocalHost => "127.0.0.1",
+        #LocalHost => "localhost",
         LocalPort => 0,
         Proto     => "udp",
     ) or die "Cannot socket - $@";
@@ -33,6 +35,7 @@ sub socketpair_inet
         Proto    => "udp",
     ) or die "Cannot socket/connect - $@";
 
+    note "Two socket connections";
     $rd->connect($wr->sockport, inet_aton($wr->sockhost)) or die "Cannot connect - $!";
 
     return ($rd, $wr);
@@ -44,7 +47,11 @@ sub socketpair_inet
 
     my $udp = UV::UDP->new;
     isa_ok($udp, 'UV::UDP');
-
+    note fileno $rd;
+    #use Win32API::File;
+    #diag Win32API::File::FdGetOsFHandle(fileno $rd);
+    # These actually show up as the correct number so the problem is not in that place
+    #diag $^E;
     $udp->open($rd);
 
     my $recv_cb_called;


### PR DESCRIPTION
These are teh accumulated changes and test fixes.

The `*-open.t` tests still don't work in all cases, as there seems to be a weird case when reading from the sockets blocks when there is no data, despite the sockets being nonblocking. But the changes shouldn't make things worse.