### PR TITLE
Test named pipes on Windows

### DIFF
--- a/t/10-pipe-connect.t
+++ b/t/10-pipe-connect.t
@@ -7,10 +7,11 @@ use UV::Pipe ();
 use Test::More;
 
 use IO::Socket::UNIX;
+use File::Basename;
 
 plan skip_all => "MSWin32 does not support AF_UNIX sockets" if $^O eq "MSWin32";
 
-my $path = "test-tmp.sock";
+my $path = basename( $0 ) . ".sock";
 my $listensock = IO::Socket::UNIX->new(
     Local => $path,
     Listen => 1,

--- a/t/10-pipe-listen.t
+++ b/t/10-pipe-listen.t
@@ -9,17 +9,26 @@ use Test::More;
 use IO::Socket::UNIX;
 use File::Basename;
 
-plan skip_all => "MSWin32 does not support AF_UNIX sockets" if $^O eq "MSWin32";
-
 my $path = basename( $0 ) . ".sock";
+my $is_win32 = $^O eq 'MSWin32';
+
+if( $is_win32) {
+    $path = "\\\\?\\pipe\\$path";
+};
 
 my $pipe = UV::Pipe->new;
 isa_ok($pipe, 'UV::Pipe');
 
 $pipe->bind($path);
-END { unlink $path if $path; }
+if( ! $is_win32 ) {
+    END { unlink $path if $path; }
+};
 
-ok(-S $path, 'Path created as a socket');
+if( $is_win32) {
+    ok(1, "$path exists on the \\\\.\\pipe\\ filesystem");
+} else {
+    ok(-S $path, 'Path created as a socket');
+};
 
 my $connection_cb_called;
 sub connection_cb {
@@ -27,9 +36,10 @@ sub connection_cb {
     $connection_cb_called++;
 
     my $client = $self->accept;
+    my $expected = $is_win32 ? '' : $path;
 
     isa_ok($client, 'UV::Pipe');
-    is($client->getsockname, $path, 'getsockname returns sockaddr');
+    is($client->getsockname, $expected, 'getsockname returns sockaddr');
 
     $self->close;
     $client->close;
@@ -37,9 +47,17 @@ sub connection_cb {
 
 $pipe->listen(5, \&connection_cb);
 
-my $sock = IO::Socket::UNIX->new(
-    Peer => $path,
-) or die "Cannot connect socket - $@"; # yes $@
+my $sock;
+
+if( $is_win32 ) {
+    $sock  = UV::Pipe->new();
+    $sock->connect($path, sub {})
+        or die "Cannot connect pipe - $@"; # yes $@
+} else {
+    $sock  = IO::Socket::UNIX->new(
+        Peer => $path,
+    ) or die "Cannot connect socket - $@"; # yes $@
+};
 
 UV::Loop->default->run;
 

--- a/t/10-pipe-listen.t
+++ b/t/10-pipe-listen.t
@@ -7,10 +7,11 @@ use UV::Pipe ();
 use Test::More;
 
 use IO::Socket::UNIX;
+use File::Basename;
 
 plan skip_all => "MSWin32 does not support AF_UNIX sockets" if $^O eq "MSWin32";
 
-my $path = "test-tmp.sock";
+my $path = basename( $0 ) . ".sock";
 
 my $pipe = UV::Pipe->new;
 isa_ok($pipe, 'UV::Pipe');


### PR DESCRIPTION
While investigating / debugging https://github.com/Grinnz/Mojo-Reactor-UV/issues/1 , I found that currently the named pipes are not tested on Windows.

Named pipes on Windows are not created using `AF_UNIX` , but as filesystem entries under the `\\.\PIPE\` namespace. This makes some OS-dependent code necessary.